### PR TITLE
feat: add pageWithoutCount to skip COUNT(*) queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,15 @@ val seeker = users.toSeeker
   .seek(_.name.asc)
   .seek(_.id.asc)
 
-// Paginate forward
+// Paginate forward (includes total count)
 val page1 = db.run(seeker.page(limit = 20, cursor = None))
 // PaginatedResult(total=100, items=[...], nextCursor=Some("..."), prevCursor=None)
 
 val page2 = db.run(seeker.page(limit = 20, cursor = page1.nextCursor))
+
+// Paginate without total count (skips the COUNT(*) query)
+val fast1 = db.run(seeker.pageWithoutCount(limit = 20, cursor = None))
+// PaginatedResultWithoutCount(items=[...], nextCursor=Some("..."), prevCursor=None)
 
 // Paginate backward
 val page0 = db.run(seeker.page(limit = 20, cursor = page1.prevCursor))

--- a/docs/docs/concepts.md
+++ b/docs/docs/concepts.md
@@ -156,9 +156,30 @@ ORDER BY
   END ASC
 ```
 
+## Pagination Without Count
+
+By default, `page()` runs a `COUNT(*)` query to include the total number of matching rows. Use `pageWithoutCount()` to skip it:
+
+```scala
+// With count (runs COUNT(*) + data query)
+val result: PaginatedResult[User] =
+  db.run(seeker.page(limit = 20, cursor = None))
+
+// Without count (runs data query only — faster)
+val result: PaginatedResultWithoutCount[User] =
+  db.run(seeker.pageWithoutCount(limit = 20, cursor = None))
+```
+
+Both methods produce interoperable cursors. You can convert between result types:
+
+```scala
+val withoutCount: PaginatedResultWithoutCount[User] = result.withoutCount
+val withCount: PaginatedResult[User] = withoutCountResult.withCount(total)
+```
+
 ## Bidirectional Pagination
 
-Slick Seeker supports both forward and backward navigation:
+Slick Seeker supports both forward and backward navigation with both `page()` and `pageWithoutCount()`:
 
 ```scala
 // Forward

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -7,7 +7,8 @@ Type-safe, high-performance cursor-based pagination for Slick 3.5+.
 - **Keyset Pagination** - O(1) performance regardless of page depth
 - **Bidirectional** - Navigate forward and backward through result sets
 - **Type-Safe** - Compile-time verification of cursor/column matching
-- **PostgreSQL Tuple Optimization** - Compile-time safe tuple comparisons for PostgreSQL (NEW!)
+- **Count-Free Pagination** - Skip `COUNT(*)` queries with `pageWithoutCount`
+- **PostgreSQL Tuple Optimization** - Compile-time safe tuple comparisons for PostgreSQL
 - **Profile Agnostic** - Works with any Slick JDBC profile (PostgreSQL, MySQL, H2, SQLite, Oracle, etc.)
 - **Flexible Ordering** - Support for nulls first/last, custom enum orders
 - **Modular** - Core + optional Play JSON integration
@@ -93,9 +94,13 @@ val seeker = users.toSeeker
   .seek(_.name.asc)      // Primary sort
   .seek(_.id.asc)        // Tiebreaker
 
-// Paginate!
+// Paginate (with total count)
 val page1 = db.run(seeker.page(limit = 20, cursor = None))
 // PaginatedResult(total=100, items=[...], nextCursor=Some("..."), prevCursor=None)
+
+// Paginate (without total count — skips the COUNT(*) query)
+val fast1 = db.run(seeker.pageWithoutCount(limit = 20, cursor = None))
+// PaginatedResultWithoutCount(items=[...], nextCursor=Some("..."), prevCursor=None)
 
 val page2 = db.run(seeker.page(limit = 20, cursor = page1.nextCursor))
 // Continue pagination...

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -112,6 +112,32 @@ case class PaginatedResult[T](
 )
 ```
 
+## PaginatedResultWithoutCount
+
+The `pageWithoutCount()` method returns a `PaginatedResultWithoutCount[T]`, skipping the `COUNT(*)` query. This is useful when the total count is not needed (e.g., infinite scroll UIs).
+
+```scala
+case class PaginatedResultWithoutCount[T](
+  items: Seq[T],           // Current page items
+  nextCursor: Option[String],  // Cursor for next page (None if last page)
+  prevCursor: Option[String]   // Cursor for previous page (None if first page)
+)
+```
+
+Usage:
+
+```scala
+// Without count (faster — no COUNT(*) query)
+val page1: Future[PaginatedResultWithoutCount[User]] =
+  db.run(seeker.pageWithoutCount(limit = 20, cursor = None))
+
+// Convert between result types
+val withCount: PaginatedResult[User] = page1WithoutCount.withCount(100)
+val withoutCount: PaginatedResultWithoutCount[User] = fullResult.withoutCount
+```
+
+Cursors are fully interoperable — a cursor from `page()` works with `pageWithoutCount()` and vice versa.
+
 ## Using with Play JSON
 
 For REST APIs, you can serialize `PaginatedResult` to JSON:
@@ -232,9 +258,10 @@ users.toPgTupleSeekerAsc     // All columns ASC
 users.toPgTupleSeekerDesc    // All columns DESC
   .seek(_.col)
 
-// Pagination (same for both)
-seeker.page(limit = 20, cursor = None)           // First page
-seeker.page(limit = 20, cursor = Some("..."))    // Next/prev page
+// Pagination (same for both seeker types)
+seeker.page(limit = 20, cursor = None)                    // With total count
+seeker.page(limit = 20, cursor = Some("..."))              // Next/prev page
+seeker.pageWithoutCount(limit = 20, cursor = None)         // Without total count
 ```
 
 ## What's Next?

--- a/slick-seeker/src/main/scala/io/github/devnico/slickseeker/package.scala
+++ b/slick-seeker/src/main/scala/io/github/devnico/slickseeker/package.scala
@@ -17,6 +17,9 @@ package object slickseeker {
   type PaginatedResult[T] = pagination.PaginatedResult[T]
   val PaginatedResult: pagination.PaginatedResult.type = pagination.PaginatedResult
 
+  type PaginatedResultWithoutCount[T] = pagination.PaginatedResultWithoutCount[T]
+  val PaginatedResultWithoutCount: pagination.PaginatedResultWithoutCount.type = pagination.PaginatedResultWithoutCount
+
   // Type aliases for cursor system
   type CursorEnvironment[E] = cursor.CursorEnvironment[E]
   val CursorEnvironment: cursor.CursorEnvironment.type = cursor.CursorEnvironment

--- a/slick-seeker/src/main/scala/io/github/devnico/slickseeker/pagination/PaginatedResultWithoutCount.scala
+++ b/slick-seeker/src/main/scala/io/github/devnico/slickseeker/pagination/PaginatedResultWithoutCount.scala
@@ -1,9 +1,9 @@
 package io.github.devnico.slickseeker.pagination
 
-/** Result of a paginated query.
+/** Result of a paginated query without total count.
   *
-  * @param total
-  *   Total number of items in the unpaginated query
+  * Use this when you don't need the total count, avoiding the extra COUNT(*) query.
+  *
   * @param items
   *   Items in this page
   * @param prevCursor
@@ -13,19 +13,18 @@ package io.github.devnico.slickseeker.pagination
   * @tparam T
   *   Type of items
   */
-final case class PaginatedResult[T](
-    total: Int,
+final case class PaginatedResultWithoutCount[T](
     items: Seq[T],
     prevCursor: Option[String],
     nextCursor: Option[String]
 ) {
 
   /** Map items to a different type while preserving pagination metadata */
-  def mapItems[U](f: T => U): PaginatedResult[U] =
+  def mapItems[U](f: T => U): PaginatedResultWithoutCount[U] =
     copy(items = items.map(f))
 
-  /** Convert to a result without total count */
-  def withoutCount: PaginatedResultWithoutCount[T] =
-    PaginatedResultWithoutCount(items, prevCursor, nextCursor)
+  /** Add a total count to produce a full PaginatedResult */
+  def withCount(total: Int): PaginatedResult[T] =
+    PaginatedResult(total, items, prevCursor, nextCursor)
 
 }

--- a/slick-seeker/src/main/scala/io/github/devnico/slickseeker/pagination/Seeker.scala
+++ b/slick-seeker/src/main/scala/io/github/devnico/slickseeker/pagination/Seeker.scala
@@ -42,4 +42,33 @@ trait Seeker[U, CVE] {
       cursorEnvironment: CursorEnvironment[CVE],
       ec: ExecutionContext
   ): profile.api.DBIOAction[PaginatedResult[U], profile.api.NoStream, profile.api.Effect.Read]
+
+  /** Execute a paginated query without computing the total count.
+    *
+    * This avoids the extra COUNT(*) query.
+    *
+    * @param limit
+    *   Maximum number of items to return
+    * @param cursor
+    *   Optional cursor for pagination navigation
+    * @param maxLimit
+    *   Maximum allowed limit
+    * @param profile
+    *   JDBC profile for database operations
+    * @param cursorEnvironment
+    *   Environment for encoding/decoding cursors
+    * @param ec
+    *   Execution context for async operations
+    * @return
+    *   Database action that returns a paginated result without total count
+    */
+  def pageWithoutCount[Profile <: JdbcProfile](
+      limit: Int,
+      cursor: Option[String],
+      maxLimit: Int
+  )(implicit
+      profile: Profile,
+      cursorEnvironment: CursorEnvironment[CVE],
+      ec: ExecutionContext
+  ): profile.api.DBIOAction[PaginatedResultWithoutCount[U], profile.api.NoStream, profile.api.Effect.Read]
 }

--- a/slick-seeker/src/test/scala/io/github/devnico/slickseeker/pagination/PaginatedResultWithoutCountSpec.scala
+++ b/slick-seeker/src/test/scala/io/github/devnico/slickseeker/pagination/PaginatedResultWithoutCountSpec.scala
@@ -1,0 +1,117 @@
+package io.github.devnico.slickseeker.pagination
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class PaginatedResultWithoutCountSpec extends AnyWordSpec with Matchers {
+
+  case class Person(id: Int, name: String)
+  case class PersonDTO(name: String)
+
+  "mapItems" should {
+    "transform items while preserving metadata" in {
+      val original = PaginatedResultWithoutCount(
+        items = Seq(Person(1, "Alice"), Person(2, "Bob")),
+        prevCursor = Some("prev"),
+        nextCursor = Some("next")
+      )
+
+      val transformed = original.mapItems(p => PersonDTO(p.name))
+
+      transformed.items shouldBe Seq(PersonDTO("Alice"), PersonDTO("Bob"))
+      transformed.prevCursor shouldBe Some("prev")
+      transformed.nextCursor shouldBe Some("next")
+    }
+
+    "handle empty items" in {
+      val original = PaginatedResultWithoutCount[Person](
+        items = Seq.empty,
+        prevCursor = None,
+        nextCursor = None
+      )
+
+      val transformed = original.mapItems(p => PersonDTO(p.name))
+
+      transformed.items shouldBe empty
+    }
+
+    "allow chaining transformations" in {
+      val original = PaginatedResultWithoutCount(
+        items = Seq(Person(1, "Alice"), Person(2, "Bob")),
+        prevCursor = None,
+        nextCursor = Some("next")
+      )
+
+      val result = original
+        .mapItems(_.name)
+        .mapItems(_.toUpperCase)
+        .mapItems(s => s"Hello, $s!")
+
+      result.items shouldBe Seq("Hello, ALICE!", "Hello, BOB!")
+      result.nextCursor shouldBe Some("next")
+    }
+
+    "preserve original on immutable semantics" in {
+      val original = PaginatedResultWithoutCount(
+        items = Seq(Person(1, "Alice")),
+        prevCursor = None,
+        nextCursor = None
+      )
+
+      val transformed = original.mapItems(p => PersonDTO(p.name))
+
+      original.items should have size 1
+      original.items.head shouldBe Person(1, "Alice")
+
+      transformed.items should have size 1
+      transformed.items.head shouldBe PersonDTO("Alice")
+    }
+  }
+
+  "PaginatedResultWithoutCount copy semantics" should {
+    "allow copying with modifications" in {
+      val original = PaginatedResultWithoutCount(
+        items = Seq(Person(1, "Alice")),
+        prevCursor = None,
+        nextCursor = Some("next")
+      )
+
+      val modified = original.copy(nextCursor = Some("other"))
+
+      modified.nextCursor shouldBe Some("other")
+      modified.items shouldBe original.items
+      modified.prevCursor shouldBe original.prevCursor
+    }
+  }
+
+  "withCount" should {
+    "convert to PaginatedResult" in {
+      val without = PaginatedResultWithoutCount(
+        items = Seq(Person(1, "Alice"), Person(2, "Bob")),
+        prevCursor = Some("prev"),
+        nextCursor = Some("next")
+      )
+
+      val withCount = without.withCount(100)
+
+      withCount.total shouldBe 100
+      withCount.items shouldBe Seq(Person(1, "Alice"), Person(2, "Bob"))
+      withCount.prevCursor shouldBe Some("prev")
+      withCount.nextCursor shouldBe Some("next")
+    }
+  }
+
+  "round-trip conversion" should {
+    "preserve all fields through withCount and withoutCount" in {
+      val original = PaginatedResultWithoutCount(
+        items = Seq(Person(1, "Alice")),
+        prevCursor = None,
+        nextCursor = Some("next")
+      )
+
+      val roundTripped = original.withCount(42).withoutCount
+
+      roundTripped shouldBe original
+    }
+  }
+}


### PR DESCRIPTION
Introduces PaginatedResultWithoutCount[T] and a pageWithoutCount method on Seeker, SlickSeeker, and SlickPgTupleSeeker. This allows paginating without the overhead of a total count query, which can be expensive on large tables.

The existing page() method is refactored to delegate to pageWithoutCount and attach the count separately. Cursors are fully interoperable between both methods.Conversion helpers withCount and withoutCount allow moving between result types.